### PR TITLE
tvOS Ui/Ux tweaks and clean-ups phase 2 (#1496)

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
@@ -69,7 +69,7 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
                 // TODO: Multirow?
                 let numberOfRows: CGFloat = 1.0
                 let width = viewWidth //- collectionView.contentInset.left - collectionView.contentInset.right / 4
-                let height = tvOSCellUnit * numberOfRows + PageIndicatorHeight
+                let height = (tvOSCellUnit + PageIndicatorHeight + 24) * numberOfRows
                 return PVSaveStateCollectionViewCell.cellSize(forImageSize: CGSize(width: width, height: height))
             case .favorites, .recents:
                 let numberOfRows: CGFloat = 1.0
@@ -112,24 +112,24 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
             switch item {
             case .none:
                 return .zero
+            case .favorites:
+                return .init(top: 0, left: -5, bottom: 20, right: 80)
+            case .saves:
+                return .init(top: 0, left: -26, bottom: 40, right: 80)
+            case .recents:
+                return .init(top: 0, left: -5, bottom: 20, right: 80)
             case .some(.game):
                 return .init(top: 20, left: 20, bottom: 25, right: 20)
-            case .saves:
-                return .init(top: -20, left: 0, bottom: 45, right: 0)
-            case .favorites:
-                return .init(top: 0, left: 20, bottom: 20, right: 20)
-            case .recents:
-                return .init(top: 0, left: 20, bottom: 20, right: 20)
             }
         #else
-        let item: Section.Item? = firstModel(in: collectionView, at: section)
-        switch item {
-        case .none:
-            return .zero
-        case .some(.game):
-            return .init(top: section == 0 ? 5 : 15, left: 10, bottom: 5, right: 10)
-        case .saves, .favorites, .recents:
-            return .zero
+            let item: Section.Item? = firstModel(in: collectionView, at: section)
+            switch item {
+            case .none:
+                return .zero
+            case .saves, .favorites, .recents:
+                return .zero
+            case .some(.game):
+                return .init(top: section == 0 ? 5 : 15, left: 10, bottom: 5, right: 10)
         }
         #endif
     }

--- a/Provenance/Game Library/UI/SaveStates/PVSaveStateCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/SaveStates/PVSaveStateCollectionViewCell.swift
@@ -44,13 +44,22 @@ final class PVSaveStateCollectionViewCell: UICollectionViewCell {
             if let saveState = saveState {
                 if let image = saveState.image {
                     imageView.image = UIImage(contentsOfFile: image.url.path)
-                    imageView.layer.borderWidth = 1.0
-                    imageView.layer.borderColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.3).cgColor
                 }
 
                 let timeText = "\(PVSaveStateCollectionViewCell.dateFormatter.string(from: saveState.date)) \(PVSaveStateCollectionViewCell.timeFormatter.string(from: saveState.date))"
                 timeStampLabel.text = timeText
-
+                
+                #if os(tvOS)
+                // Set up initial textColor for the savestate labels to match the other titles and allow for animation to white for our popup effect when focussed
+                    timeStampLabel.textColor = UIColor.darkGray
+                    titleLabel.textColor = UIColor.darkGray
+                    coreLabel.textColor = UIColor.darkGray
+                    
+                // Set up nicer Save State image filtering on tvOS
+                    imageView.layer.shouldRasterize = true
+                    imageView.layer.rasterizationScale = 2.0
+                #endif
+                
                 guard let game = saveState.game, let system = game.system, !system.cores.isEmpty else {
                     let gameNil = saveState.game == nil ? "true" : "false"
                     let systemNil = saveState.game?.system == nil ? "true" : "false"
@@ -113,16 +122,22 @@ final class PVSaveStateCollectionViewCell: UICollectionViewCell {
     #if os(tvOS)
         override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
             super.didUpdateFocus(in: context, with: coordinator)
-            imageView.layer.borderWidth = 0.0
+ //           imageView.layer.borderWidth = 0.0
             coordinator.addCoordinatedAnimations({ () -> Void in
                 if self.isFocused {
-                    let yOffset = self.imageView.frame.maxY - self.labelContainer.frame.minY + 48
-                    let labelTransform = CGAffineTransform(scaleX: 1.2, y: 1.2).translatedBy(x: 0, y: yOffset)
+                    let yOffset = self.imageView.frame.maxY - self.labelContainer.frame.minY + 36
+                    let labelTransform = CGAffineTransform(scaleX: 1.25, y: 1.25).translatedBy(x: 0, y: yOffset)
                     self.labelContainer.transform = labelTransform
+                    self.timeStampLabel.textColor = UIColor.white
+                    self.titleLabel.textColor = UIColor.white
+                    self.coreLabel.textColor = UIColor.white
                     self.sizeToFit()
                     self.superview?.bringSubviewToFront(self)
                 } else {
                     self.labelContainer.transform = .identity
+                    self.timeStampLabel.textColor = UIColor.darkGray
+                    self.titleLabel.textColor = UIColor.darkGray
+                    self.coreLabel.textColor = UIColor.darkGray
                 }
             }) { () -> Void in }
         }

--- a/ProvenanceTV/PVSearchViewController.swift
+++ b/ProvenanceTV/PVSearchViewController.swift
@@ -34,6 +34,8 @@ final class PVSearchViewController: UICollectionViewController, GameLaunchingVie
         self.gameLibrary = gameLibrary
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.sectionInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+        flowLayout.minimumInteritemSpacing = 120.0
+        flowLayout.minimumLineSpacing = 20.0
         super.init(collectionViewLayout: flowLayout)
     }
 
@@ -43,12 +45,8 @@ final class PVSearchViewController: UICollectionViewController, GameLaunchingVie
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        #if os(iOS)
-            collectionView?.register(UINib(nibName: "PVGameLibraryCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: PVGameLibraryCollectionViewCellIdentifier)
-        #else
-            collectionView?.register(UINib(nibName: "PVGameLibraryCollectionViewCell~tvOS", bundle: nil), forCellWithReuseIdentifier: PVGameLibraryCollectionViewCellIdentifier)
-            collectionView?.backgroundColor = .black
-        #endif
+        collectionView?.register(UINib(nibName: "PVGameLibraryCollectionViewCell~tvOS", bundle: nil), forCellWithReuseIdentifier: PVGameLibraryCollectionViewCellIdentifier)
+        collectionView?.backgroundColor = .black
         collectionView?.contentInset = UIEdgeInsets(top: 40, left: 80, bottom: 40, right: 80)
 
         let sections: Observable<[Section]> = searchController


### PR DESCRIPTION
* Show Page Indicator correctly on the Recently Saved Title row.

Pad out row height to allow for the PageIndicators to be visible again.

* Align recent / save game / favorite rows to left side

Add manual kerning to align the left side of the category insets on tvOS.

* Clean up SearchViewController for tvOS.

Sets up proper title spacing and layouts for titles reported by the Search Controller.
Removes old iOS specific checks

* Removes 1pixel border around savegame images

To match the other image tiles we use across the system.

* saveGame titleLabels now match other Labels on tvOS

Sets default state to match the darkGray textColor of the other labels.
Animate on focus turns the labels white for optimal readability like the other labels.
When shifting focus to another title the color returns to the default darkGray.
Match scale and offset when focussing to the behaviour the other Titles have.

* Add in filtering for saveState screenshots on tvOS

Make sure this is set for 2x filtering by default before initializing the SavestateCollectionViewCell

### What does this PR do

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
